### PR TITLE
Adding unknown label

### DIFF
--- a/example.py
+++ b/example.py
@@ -2,15 +2,15 @@ from speaker_identifier import SpeakerIdentifier, TrainingType, display_predicti
 
 
 """ Flags for execution control"""
-TRAINING_TYPE = TrainingType.PREPARE_DATA_AND_TRAIN
+# TRAINING_TYPE = TrainingType.PREPARE_DATA_AND_TRAIN
 # TRAINING_TYPE = TrainingType.TRAIN_ONLY
-# TRAINING_TYPE = TrainingType.NO_TRAINING
+TRAINING_TYPE = TrainingType.NO_TRAINING
 
 ADD_NOISE_TO_TRAINING_DATA = False
-PREPARE_TEST_DATA = True
+PREPARE_TEST_DATA = False
 
-TRAINING_VAD = True
-PREDICTING_VAD = True
+TRAINING_VAD = False
+PREDICTING_VAD = False
 
 
 def main():

--- a/example.py
+++ b/example.py
@@ -2,15 +2,15 @@ from speaker_identifier import SpeakerIdentifier, TrainingType, display_predicti
 
 
 """ Flags for execution control"""
-# TRAINING_TYPE = TrainingType.PREPARE_DATA_AND_TRAIN
+TRAINING_TYPE = TrainingType.PREPARE_DATA_AND_TRAIN
 # TRAINING_TYPE = TrainingType.TRAIN_ONLY
-TRAINING_TYPE = TrainingType.NO_TRAINING
+# TRAINING_TYPE = TrainingType.NO_TRAINING
 
 ADD_NOISE_TO_TRAINING_DATA = False
-PREPARE_TEST_DATA = False
+PREPARE_TEST_DATA = True
 
-TRAINING_VAD = False
-PREDICTING_VAD = False
+TRAINING_VAD = True
+PREDICTING_VAD = True
 
 
 def main():

--- a/speaker_identifier/helpers.py
+++ b/speaker_identifier/helpers.py
@@ -58,28 +58,38 @@ def display_predictions(predictions, correctly_identified):
         certainty_measure = detail["certainty_measure"]
         speaker_labels = detail["speaker_labels"]
         max_prediction = np.max(certainty_measure)
-
-        print(
-            f"\nCorrect speaker: {correct_speaker}, predicted speaker is {predicted_speaker}"
-        )
-
+        
+        test_speaker_labels = [name for name in os.listdir(Config.dataset_test) if os.path.isdir(os.path.join(Config.dataset_test, name))]
+        
+        if predicted_speaker in test_speaker_labels:
+            print(f"\nCorrect speaker: {correct_speaker}, predicted speaker is {predicted_speaker}")
+        else:
+            print(f"\nCorrect speaker: {correct_speaker}, predicted speaker is unknown")
+            
         for i in range(len(certainty_measure)):
             if certainty_measure[i] > 5:
                 if (
                     certainty_measure[i] == max_prediction
                     and speaker_labels[i] == correct_speaker
                 ):
-                    print(
-                        f"\033[1;32;40m {speaker_labels[i]}: {certainty_measure[i]:.2f}% \033[0m"
-                    )
+                    if speaker_labels[i] in test_speaker_labels:
+                        print(f"\033[1;32;40m {speaker_labels[i]}: {certainty_measure[i]:.2f}% \033[0m")
+                    else:
+                        print(f"\033[1;32;40m unknown speaker: {certainty_measure[i]:.2f}% \033[0m")
+                    
                 elif (
                     certainty_measure[i] == max_prediction
                     and speaker_labels[i] != correct_speaker
                 ):
-                    print(
-                        f"\033[1;31;40m {speaker_labels[i]}: {certainty_measure[i]:.2f}% \033[0m"
-                    )
+                    if speaker_labels[i] in test_speaker_labels:
+                        print(f"\033[1;31;40m {speaker_labels[i]}: {certainty_measure[i]:.2f}% \033[0m")
+                    else:
+                        print(f"\033[1;31;40m unknown speaker: {certainty_measure[i]:.2f}% \033[0m")
+                        
                 else:
-                    print(f"{speaker_labels[i]}: {certainty_measure[i]:.2f}%")
+                    if speaker_labels[i] in test_speaker_labels:
+                        print(f"{speaker_labels[i]}: {certainty_measure[i]:.2f}%")
+                    else:
+                        print(f"unknown speaker: {certainty_measure[i]:.2f}%")
 
     print(f"\nCorrectly identified speakers: {correctly_identified}")

--- a/speaker_identifier/helpers.py
+++ b/speaker_identifier/helpers.py
@@ -66,6 +66,7 @@ def display_predictions(predictions, correctly_identified):
         else:
             print(f"\nCorrect speaker: {correct_speaker}, predicted speaker is unknown")
             
+        j=1
         for i in range(len(certainty_measure)):
             if certainty_measure[i] > 5:
                 if (
@@ -75,7 +76,8 @@ def display_predictions(predictions, correctly_identified):
                     if speaker_labels[i] in test_speaker_labels:
                         print(f"\033[1;32;40m {speaker_labels[i]}: {certainty_measure[i]:.2f}% \033[0m")
                     else:
-                        print(f"\033[1;32;40m unknown speaker: {certainty_measure[i]:.2f}% \033[0m")
+                        print(f"\033[1;32;40m unknown speaker {j}: {certainty_measure[i]:.2f}% \033[0m")
+                        j=j+1
                     
                 elif (
                     certainty_measure[i] == max_prediction
@@ -84,12 +86,14 @@ def display_predictions(predictions, correctly_identified):
                     if speaker_labels[i] in test_speaker_labels:
                         print(f"\033[1;31;40m {speaker_labels[i]}: {certainty_measure[i]:.2f}% \033[0m")
                     else:
-                        print(f"\033[1;31;40m unknown speaker: {certainty_measure[i]:.2f}% \033[0m")
+                        print(f"\033[1;31;40m unknown speaker {j}: {certainty_measure[i]:.2f}% \033[0m")
+                        j=j+1
                         
                 else:
                     if speaker_labels[i] in test_speaker_labels:
                         print(f"{speaker_labels[i]}: {certainty_measure[i]:.2f}%")
                     else:
-                        print(f"unknown speaker: {certainty_measure[i]:.2f}%")
+                        print(f"unknown speaker {j}: {certainty_measure[i]:.2f}%")
+                        j=j+1
 
     print(f"\nCorrectly identified speakers: {correctly_identified}")

--- a/speaker_identifier/helpers.py
+++ b/speaker_identifier/helpers.py
@@ -66,7 +66,7 @@ def display_predictions(predictions, correctly_identified):
         else:
             print(f"\nCorrect speaker: {correct_speaker}, predicted speaker is unknown")
             
-        j=1
+        unknown_speaker_label=1
         for i in range(len(certainty_measure)):
             if certainty_measure[i] > 5:
                 if (
@@ -76,8 +76,8 @@ def display_predictions(predictions, correctly_identified):
                     if speaker_labels[i] in test_speaker_labels:
                         print(f"\033[1;32;40m {speaker_labels[i]}: {certainty_measure[i]:.2f}% \033[0m")
                     else:
-                        print(f"\033[1;32;40m unknown speaker {j}: {certainty_measure[i]:.2f}% \033[0m")
-                        j=j+1
+                        print(f"\033[1;32;40m unknown speaker {unknown_speaker_label}: {certainty_measure[i]:.2f}% \033[0m")
+                        unknown_speaker_label=unknown_speaker_label+1
                     
                 elif (
                     certainty_measure[i] == max_prediction
@@ -86,14 +86,14 @@ def display_predictions(predictions, correctly_identified):
                     if speaker_labels[i] in test_speaker_labels:
                         print(f"\033[1;31;40m {speaker_labels[i]}: {certainty_measure[i]:.2f}% \033[0m")
                     else:
-                        print(f"\033[1;31;40m unknown speaker {j}: {certainty_measure[i]:.2f}% \033[0m")
-                        j=j+1
+                        print(f"\033[1;31;40m unknown speaker {unknown_speaker_label}: {certainty_measure[i]:.2f}% \033[0m")
+                        unknown_speaker_label=unknown_speaker_label+1
                         
                 else:
                     if speaker_labels[i] in test_speaker_labels:
                         print(f"{speaker_labels[i]}: {certainty_measure[i]:.2f}%")
                     else:
-                        print(f"unknown speaker {j}: {certainty_measure[i]:.2f}%")
-                        j=j+1
+                        print(f"unknown speaker {unknown_speaker_label}: {certainty_measure[i]:.2f}%")
+                        unknown_speaker_label=unknown_speaker_label+1
 
     print(f"\nCorrectly identified speakers: {correctly_identified}")


### PR DESCRIPTION
In this version there's unknown 1, 2, 3 label for each of the "unknown" speakers. In principle one could add one
"unknown" label, but this would require to sum over all "unknown" certainty_measures, and this could be larger
than certainty_measure even for correctly identified speaker. So this way I think is less confusing.